### PR TITLE
fix: 修复主页登录时header偏移问题

### DIFF
--- a/app/ui/globals.scss
+++ b/app/ui/globals.scss
@@ -122,3 +122,14 @@ header {
   background-size: 100% 3px;
   background-position: 0 100%;
 }
+
+:root {
+    overflow-y: auto;
+    overflow-x: hidden;
+}
+
+body {
+    position: absolute;
+    width: 100vw;
+    overflow: hidden;
+}


### PR DESCRIPTION
在访问您的网站时，我注意到点击登录时，触发模态框会导致header的layout偏移，这是一个解决方案:)